### PR TITLE
Remove dependency on json_annotation

### DIFF
--- a/lib/document.dart
+++ b/lib/document.dart
@@ -1,5 +1,4 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:json_annotation/json_annotation.dart';
 import 'base.dart';
 import 'enum/execute_type.dart';
 import 'flamingo.dart';
@@ -45,32 +44,23 @@ class Document<T> extends Base implements DocumentType {
   }
 
   /// Field
-  @JsonKey(ignore: true)
   Timestamp createdAt;
 
-  @JsonKey(ignore: true)
   Timestamp updatedAt;
 
-  @JsonKey(ignore: true)
   String id;
 
   /// Reference
-  @JsonKey(ignore: true)
   String collectionPath;
 
-  @JsonKey(ignore: true)
   String documentPath;
 
-  @JsonKey(ignore: true)
   final CollectionReference collectionRef;
 
-  @JsonKey(ignore: true)
   DocumentReference reference;
 
-  @JsonKey(ignore: true)
   final DocumentSnapshot snapshot;
 
-  @JsonKey(ignore: true)
   final Map<String, dynamic> values;
 
   /// Public method.

--- a/lib/model/model.dart
+++ b/lib/model/model.dart
@@ -1,4 +1,3 @@
-import 'package:json_annotation/json_annotation.dart';
 import '../base.dart';
 
 class Model extends Base {
@@ -8,7 +7,6 @@ class Model extends Base {
     }
   }
 
-  @JsonKey(ignore: true)
   final Map<String, dynamic> values;
 
   Map<String, dynamic> toData() => <String, dynamic>{};

--- a/lib/model/storage_file.dart
+++ b/lib/model/storage_file.dart
@@ -1,8 +1,5 @@
-import 'package:json_annotation/json_annotation.dart';
-
 part 'storage_file.g.dart';
 
-@JsonSerializable(nullable: true)
 class StorageFile {
   StorageFile(
       {this.name,
@@ -14,10 +11,8 @@ class StorageFile {
   factory StorageFile.fromJson(Map<String, dynamic> json) =>
       _$StorageFileFromJson(json);
 
-  @JsonKey(ignore: true)
   bool isDeleted = false;
 
-  @JsonKey(ignore: true)
   String folderName;
 
   String name;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  json_annotation: ^3.0.0
   path_provider: ^1.5.1
   firebase_core: ^0.4.3+1
   cloud_firestore: ^0.13.0+1


### PR DESCRIPTION
I removed dependency on `json_annotation` because Flamingo is not using `json_serializer`.

We want to install [in_app_purchase](https://pub.dev/packages/in_app_purchase) but dependency error will cause.

```
Because in_app_purchase >=0.1.0 depends on json_annotation ^2.0.0 and every version of flamingo depends on json_annotation ^3.0.0, in_app_purchase >=0.1.0 is incompatible with flamingo.
So, because hop depends on both flamingo ^0.1.1+2 and in_app_purchase ^0.2.2+4, version solving failed.
pub upgrade failed (1; So, because hop depends on both flamingo ^0.1.1+2 and in_app_purchase ^0.2.2+4, version solving failed.)
```

Current Flamingo depends on `json_annotation` ^3.0.0, but in_app_purchase depends on `json_annotation` ^2.0.0.

in_app_purchase is using generated files by `json_serializer` and  `json_annotation` but Flamingo is only annotating, is not using `json_serializer`.
I think it's good to remove dependency on `json_annotation` so I remove it.