### PR TITLE
Set default values for matadata and additionalData for compatibility …

### DIFF
--- a/lib/model/storage_file.dart
+++ b/lib/model/storage_file.dart
@@ -5,9 +5,9 @@ class StorageFile {
       {this.name,
       this.path,
       this.url,
-      this.mimeType,
-      this.additionalData,
-      this.metadata});
+      this.mimeType = 'application/octet-stream',
+      this.additionalData = const <String, dynamic>{},
+      this.metadata = const <String, String>{}});
   factory StorageFile.fromJson(Map<String, dynamic> json) =>
       _$StorageFileFromJson(json);
 

--- a/lib/storage.dart
+++ b/lib/storage.dart
@@ -1,21 +1,27 @@
 import 'dart:async';
 import 'dart:io';
+
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_storage/firebase_storage.dart';
+
 import 'flamingo.dart';
 
 class Storage {
-
   static String fileName({int length}) => Helper.randomString(length: length);
 
   final _storage = storageInstance();
+
   FirebaseStorage get storage => _storage;
 
   StreamController<StorageTaskEvent> _uploader;
+
   Stream<StorageTaskEvent> get uploader => _uploader.stream;
 
   Future<StorageFile> save(String folderPath, File data,
-      {String fileName, String mimeType, Map<String, String> metadata}) async {
+      {String fileName,
+      String mimeType = 'application/octet-stream',
+      Map<String, String> metadata = const <String, String>{},
+      Map<String, dynamic> additionalData = const <String, dynamic>{}}) async {
     final refFileName = fileName != null ? fileName : Storage.fileName();
     final refMimeType = mimeType != null ? mimeType : '';
     final path = '$folderPath/$refFileName';
@@ -35,6 +41,7 @@ class Storage {
       path: path,
       mimeType: refMimeType,
       metadata: metadata,
+      additionalData: additionalData,
     );
   }
 
@@ -50,10 +57,15 @@ class Storage {
     return;
   }
 
-  Future<StorageFile> saveWithDoc(DocumentReference reference, String folderName, File data,
-      {String fileName, String mimeType, Map<String, String> metadata, Map<String, dynamic> additionalData}) async {
+  Future<StorageFile> saveWithDoc(
+      DocumentReference reference, String folderName, File data,
+      {String fileName,
+      String mimeType = 'application/octet-stream',
+      Map<String, String> metadata = const <String, String>{},
+      Map<String, dynamic> additionalData = const <String, dynamic>{}}) async {
     final folderPath = '${reference.path}/$folderName';
-    final storageFile = await save(folderPath, data, fileName: fileName, mimeType: mimeType, metadata: metadata);
+    final storageFile = await save(folderPath, data,
+        fileName: fileName, mimeType: mimeType, metadata: metadata);
     storageFile.additionalData = additionalData;
     final documentAccessor = DocumentAccessor();
     final values = <String, dynamic>{};
@@ -62,7 +74,9 @@ class Storage {
     return storageFile;
   }
 
-  Future<void> deleteWithDoc(DocumentReference reference, String folderName, StorageFile storageFile, {bool isNotNull = true}) async {
+  Future<void> deleteWithDoc(
+      DocumentReference reference, String folderName, StorageFile storageFile,
+      {bool isNotNull = true}) async {
     final folderPath = '${reference.path}/$folderName';
     await delete(folderPath, storageFile);
     if (storageFile.isDeleted) {


### PR DESCRIPTION
Ballcapでは `metadata` と `additionalData` のデフォルト値に空Mapが使われています。
Flamingoでも、metadataなどの指定を省略した場合に空Mapが入ってくれると嬉しいです。

https://github.com/1amageek/Ballcap-iOS/blob/master/Ballcap/File/File.swift#L56

その他、いくつかの値のデフォルト値をBallcapと揃えました。