### PR TITLE
Fix: Add empty List during updation

### DIFF
--- a/lib/base.dart
+++ b/lib/base.dart
@@ -85,7 +85,7 @@ class Base {
   void _writeStorageList(
       Map<String, dynamic> data, String key, List<StorageFile> storageFiles,
       {bool isSetNull}) {
-    if (storageFiles != null && storageFiles.isNotEmpty) {
+    if (storageFiles != null) {
       data[key] = storageFiles
           .where((d) => d.isDeleted != true)
           .map((d) => d.toJson())


### PR DESCRIPTION
Description:
During updation, Empty List was not being accepted,
Which makes the empty list always non-empty

Changes made: 
Removed the condition for `storageFiles.isNotEmpty`
